### PR TITLE
FH-1576 - Can't capture location app forms on iPhone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - template-config
 
+## 1.5.1 - Martin Murphy
+
+* FH-1576 - Include appforms client template with updated Cordova plugin versions
+
 ## 1.5.0 - Niall Donnelly
 
 * FH-1518 Updated Appforms Template Client To Use Cordova Alerts Where Available

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-config",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "FeedHenry Template Applications",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Created new project and new form. Added location field and built and installed on iPhone.  Clicking the "Capture Location" button displays "location could not be determined".

There does not appear to be a way to manually add the location information.

Reproduced on iPone 4S and 5S.

Tested and does not appear to be a problem on Android 5.1.1