### PR TITLE
RFC - Datasource templates

### DIFF
--- a/global.json
+++ b/global.json
@@ -1634,6 +1634,29 @@
             "category": "DataSources"
           }
         ]
+      },
+      {
+        "id": "datasource_mongodb",
+        "priority": 0.72,
+        "name": "MongoDB Data DataSource",
+        "type": "other",
+        "image": "public/img/cloud_plugins/fh.png",
+        "category": "DataSources",
+        "docs": "https://raw.githubusercontent.com/feedhenry-templates/appforms-datasources-mongodb/master/README.md",
+        "description": "A service for integrating with DataSources backed by MongoDB",
+        "appTemplates": [
+          {
+            "id": "mongodb_datasource_cloud",
+            "name": "MongoDB DataSources",
+            "docs": "https://raw.githubusercontent.com/feedhenry-templates/appforms-datasources-mongodb/master/README.md",
+            "type": "cloud_nodejs",
+            "repoUrl": "git://github.com/feedhenry-templates/appforms-datasources-mongodb.git",
+            "githubUrl": "https://github.com/feedhenry-templates/appforms-datasources-mongodb.git",
+            "repoBranch": "refs/heads/master",
+            "image": "public/img/cloud_plugins/fh.png",
+            "category": "DataSources"
+          }
+        ]
       }
     ]
   },

--- a/global.json
+++ b/global.json
@@ -1611,6 +1611,29 @@
             ]
           }
         ]
+      },
+      {
+        "id": "datasource_static",
+        "priority": 0.73,
+        "name": "Static Data DataSource",
+        "type": "other",
+        "image": "public/img/cloud_plugins/fh.png",
+        "category": "DataSources",
+        "docs": "https://raw.githubusercontent.com/feedhenry-templates/appforms-datasources-static/master/README.md",
+        "description": "A service for integrating with DataSources",
+        "appTemplates": [
+          {
+            "id": "static_datasource_cloud",
+            "name": "Static DataSources",
+            "docs": "https://raw.githubusercontent.com/feedhenry-templates/appforms-datasources-static/master/README.md",
+            "type": "cloud_nodejs",
+            "repoUrl": "git://github.com/feedhenry-templates/appforms-datasources-static.git",
+            "githubUrl": "https://github.com/feedhenry-templates/appforms-datasources-static.git",
+            "repoBranch": "refs/heads/master",
+            "image": "public/img/cloud_plugins/fh.png",
+            "category": "DataSources"
+          }
+        ]
       }
     ]
   },

--- a/global.json
+++ b/global.json
@@ -1657,6 +1657,29 @@
             "category": "DataSources"
           }
         ]
+      },
+      {
+        "id": "datasource_internet",
+        "priority": 0.71,
+        "name": "Internet Data DataSource",
+        "type": "other",
+        "image": "public/img/cloud_plugins/fh.png",
+        "category": "DataSources",
+        "docs": "https://raw.githubusercontent.com/feedhenry-templates/appforms-datasources-internet/master/README.md",
+        "description": "A service for integrating with DataSources backed by data from the Internet",
+        "appTemplates": [
+          {
+            "id": "internet_datasource_cloud",
+            "name": "Internet DataSources",
+            "docs": "https://raw.githubusercontent.com/feedhenry-templates/appforms-datasources-internet/master/README.md",
+            "type": "cloud_nodejs",
+            "repoUrl": "git://github.com/feedhenry-templates/appforms-datasources-internet.git",
+            "githubUrl": "https://github.com/feedhenry-templates/appforms-datasources-internet.git",
+            "repoBranch": "refs/heads/master",
+            "image": "public/img/cloud_plugins/fh.png",
+            "category": "DataSources"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
replacing #74 with this one:

This is the for the series of JIRA's for creating sample Datasource services.

Hardcoded - https://issues.jboss.org/browse/RHMAP-2456
MongoDB - https://issues.jboss.org/browse/RHMAP-2457
From the Internet - https://issues.jboss.org/browse/RHMAP-2457

This initial PR is probably going to eventually be 3 commits, one for each template type